### PR TITLE
Simplify brand kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,23 @@
 # Alephium Brand Guide
-Repository for Alephium's production-ready graphic identity. Alephium is a young project that is evolving at high pace. The brand reflects this nature and may therefor be subject to changes.
+Repository for Alephium's production-ready graphic identity. Alephium is a project that is evolving at high pace. The brand reflects this nature and may therefor be subject to changes.
 
 ## Logo's colors
 
-We love having both dark and light themes. Make sure to use the right logo to ensure good contrast.
+We recommend using the variant of the logo with a dark grey background when used as the token logo. In general, this is the preferred logo as it works well on both light and dark backgrounds.
 
-The left part of the logo must be either pure black or pure white depending on your background. The top right accent must be Orange/red (#ff5d51)
-
-![image](https://user-images.githubusercontent.com/3484593/153620586-ccfbd7cd-8362-4cf5-ab67-77b593cd8ca5.png)
-
+![Alephium-brand-kit_1](https://github.com/user-attachments/assets/1aaacfee-3257-4452-b078-1d3c767b0583)
 
 
 ## Logo's layout
 
-![image](https://user-images.githubusercontent.com/3484593/153619901-d8dca6b7-81a5-4d70-8b24-e0cf814dadab.png)
+Here are the 3 possible layouts for external usage. Please don't use the wordmark alone.
 
+![Alephium-brand-kit_2](https://github.com/user-attachments/assets/4f9ce375-0e63-474e-b01b-afd7c4d01e41)
 
-
-## Colors
-### Base colors
-- Purple: #1200da
-- Orange/Red: #ff5d51
-- Black: #000000
-- White: #ffffff
 
 ## Fonts
 
 ### The Inter typeface family
-Inter is a typeface carefully crafted & designed for computer screens.
+We use Inter, an open source typeface carefully crafted & designed for computer screens.
 
-_Inter features a tall x-height to aid in readability of mixed-case and lower-case text. Several OpenType features are provided as well, like contextual alternates that adjusts punctuation depending on the shape of surrounding glyphs, slashed zero for when you need to disambiguate "0" from "o", tabular numbers, etc._ - https://rsms.me/inter/ 
-
-![Inter Regular](https://rsms.me/inter/samples/img/a-z-regular.svg "Inter Bold")
-
-![Inter Regular](https://rsms.me/inter/samples/img/lineup-bold-black.svg  "Inter Bold")
+https://rsms.me/inter/


### PR DESCRIPTION
First step to avoid community to use the red accent legacy logo. 
Next up: I'll simplify the project structure, remove most of the variants, and update the logo font to Inter.
To be further discussed with @VDAODAO.